### PR TITLE
Second batch of PR review comments addressed

### DIFF
--- a/.github/Contributing.md
+++ b/.github/Contributing.md
@@ -1,0 +1,90 @@
+## <a name="commit"></a> Commit Message Guidelines
+
+We have very precise rules over how our git commit messages can be formatted.  This leads to **more
+readable messages** that are easy to follow when looking through the **project history**. For full contributiong guidelines visit
+the [Contributors Guide](https://wiki.edgexfoundry.org/display/FA/Committing+Code+Guidelines#CommittingCodeGuidelines-Commits) on the EdgeX Wiki
+
+### Commit Message Format
+Each commit message consists of a **header**, a **body** and a **footer**.  The header has a special
+format that includes a **type**, a **scope** and a **subject**:
+
+```
+<type>(<scope>): <subject>
+<BLANK LINE>
+<body>
+<BLANK LINE>
+<footer>
+```
+
+The **header** is mandatory and the **scope** of the header is optional.
+
+Any line of the commit message cannot be longer 100 characters! This allows the message to be easier
+to read on GitHub as well as in various git tools.
+
+The footer should contain a [closing reference to an issue](https://help.github.com/articles/closing-issues-via-commit-messages/) if any.
+
+Example 1:
+```
+build(makefile): add docker support
+```
+```
+fix(logging): Initialize remote logging properly
+
+Previously remote logging failed due to improper initialization of the logging client. This commit fixes the initialization to properly support remote logging.
+
+Closes: #123
+```
+
+### Revert
+If the commit reverts a previous commit, it should begin with `revert: `, followed by the header of the reverted commit. In the body it should say: `This reverts commit <hash>.`, where the hash is the SHA of the commit being reverted.
+
+### Type
+Must be one of the following:
+
+* **build**: Changes that affect the CI/CD pipline or build system or external dependencies (example scopes: travis, jenkins, makefile)
+* **docs**: Documentation only changes
+* **feat**: A new feature
+* **fix**: A bug fix
+* **perf**: A code change that improves performance
+* **refactor**: A code change that neither fixes a bug nor adds a feature
+* **style**: Changes that do not affect the meaning of the code (white-space, formatting, etc)
+* **test**: Adding missing tests or correcting existing tests
+
+### Scope
+The scope should be the name of the module or package affected (as perceived by the person reading the changelog generated from commit messages.
+
+The following is the list of suggested scopes:
+
+Modules:
+* **messaging**
+* **core-contracts**
+* **registry**
+
+Packages:
+* **sdk**
+* **context**
+* **transforms**
+* **startup**
+* **config**
+* **logging**
+* **helpers**
+* **telemetry**
+* **triggers**
+
+
+### Subject
+The subject contains a succinct description of the change:
+
+* use the imperative, present tense: "change" not "changed" nor "changes"
+* don't capitalize the first letter
+* no dot (.) at the end
+
+### Body
+Just as in the **subject**, use the imperative, present tense: "change" not "changed" nor "changes".
+The body should include the motivation for the change and contrast this with previous behavior.
+
+### Footer
+The footer should contain any information about **Breaking Changes** and is also the place to
+reference GitHub issues that this commit **Closes**.
+
+**Breaking Changes** should start with the word `BREAKING CHANGE:` with a space or two newlines. The rest of the commit message is then used for this.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,10 @@
 ## PR Checklist
 Please check if your PR fulfills the following requirements:
 
-- [ ] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
 - [ ] Tests for the changes have been added (for bug fixes / features)
 - [ ] Docs have been added / updated (for bug fixes / features)
+
+<!-- If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/master/.github/CONTRIBUTING.md -->
 
 ## PR Type
 What kind of change does this PR introduce?

--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,0 +1,16 @@
+allowMergeCommits: true
+# Always validate the PR title AND all the commits
+titleAndCommits: true
+types:
+  - feat
+  - fix
+  - improvement
+  - docs
+  - style
+  - refactor
+  - perf
+  - test
+  - build
+  - ci
+  - chore
+  - revert

--- a/internal/inventory/circularbuffer.go
+++ b/internal/inventory/circularbuffer.go
@@ -9,30 +9,30 @@ import (
 	"sync"
 )
 
-// CircularBuffer is essentially a moving slice with a max size, where every time a new value is inserted,
+// circularBuffer is essentially a moving slice with a max size, where every time a new value is inserted,
 // the oldest value is removed from the slice. This is used for calculating moving averages of values over time.
 // For performance reasons it is implemented as a fixed size slice with a pointer to where to insert the next value
 // such that no new memory allocations need to be made.
-type CircularBuffer struct {
+type circularBuffer struct {
 	values []float64
 	total  float64
 	index  int
 	mutex  sync.RWMutex
 }
 
-// NewCircularBuffer allocates memory for a new CircularBuffer with the given windowSize
-func NewCircularBuffer(windowSize int) *CircularBuffer {
+// newCircularBuffer allocates memory for a new circularBuffer with the given windowSize
+func newCircularBuffer(windowSize int) *circularBuffer {
 	if windowSize <= 0 {
 		panic("illegal window size")
 	}
 
-	return &CircularBuffer{
+	return &circularBuffer{
 		values: make([]float64, 0, windowSize),
 	}
 }
 
 // Len returns the number of actual values present in the buffer
-func (buff *CircularBuffer) Len() int {
+func (buff *circularBuffer) Len() int {
 	buff.mutex.RLock()
 	defer buff.mutex.RUnlock()
 
@@ -43,7 +43,7 @@ func (buff *CircularBuffer) Len() int {
 // Because this is a circular buffer, this value can be considered as a moving average
 //
 // NOTE: If there is no data in the buffer, this function will return: Nan
-func (buff *CircularBuffer) Mean() float64 {
+func (buff *circularBuffer) Mean() float64 {
 	buff.mutex.RLock()
 	defer buff.mutex.RUnlock()
 
@@ -52,7 +52,7 @@ func (buff *CircularBuffer) Mean() float64 {
 
 // AddValue appends a new value onto the backing slice,
 // overriding the oldest existing value if count has reached windowSize
-func (buff *CircularBuffer) AddValue(value float64) {
+func (buff *circularBuffer) AddValue(value float64) {
 	buff.mutex.Lock()
 	defer buff.mutex.Unlock()
 

--- a/internal/inventory/circularbuffer_test.go
+++ b/internal/inventory/circularbuffer_test.go
@@ -16,7 +16,7 @@ var (
 	epsilon = math.Nextafter(1.0, 2.0) - 1.0
 )
 
-func assertBufferSize(t *testing.T, buff *CircularBuffer, expectedSize int) {
+func assertBufferSize(t *testing.T, buff *circularBuffer, expectedSize int) {
 	if buff.Len() != expectedSize {
 		t.Errorf("expected buffer size of %d, but was %d", buff.Len(), expectedSize)
 	}
@@ -28,7 +28,7 @@ func TestCircularBuffer_AddValue(t *testing.T) {
 	for _, window := range windowSizes {
 		window := window
 		t.Run(fmt.Sprintf("WindowOf%d", window), func(t *testing.T) {
-			buff := NewCircularBuffer(window)
+			buff := newCircularBuffer(window)
 
 			assertBufferSize(t, buff, 0)
 			// fill up the buffer
@@ -83,7 +83,7 @@ func TestCircularBuffer_GetMean(t *testing.T) {
 	for _, test := range tests {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
-			buff := NewCircularBuffer(test.window)
+			buff := newCircularBuffer(test.window)
 			for _, val := range test.data {
 				buff.AddValue(val)
 			}
@@ -127,7 +127,7 @@ func TestCircularBuffer_GetCount(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			buff := NewCircularBuffer(test.windowSize)
+			buff := newCircularBuffer(test.windowSize)
 			var i uint64
 			for i = 0; i < test.numberToAdd; i++ {
 				buff.AddValue(1.0)
@@ -143,7 +143,7 @@ func TestCircularBuffer_GetCount(t *testing.T) {
 
 func TestCircularBuffer_Wrap(t *testing.T) {
 	windowSize := 10
-	buff := NewCircularBuffer(windowSize)
+	buff := newCircularBuffer(windowSize)
 
 	assertBufferSize(t, buff, 0)
 	// fill up the buffer

--- a/internal/inventory/config.go
+++ b/internal/inventory/config.go
@@ -61,7 +61,7 @@ func NewConsulConfig() ConsulConfig {
 			MobilityProfileHoldoffMillis: 500,
 			MobilityProfileSlope:         -0.008,
 			DeviceServiceName:            "edgex-device-llrp",
-			DeviceServiceURL:             "http://edgex-device-llrp:51992/",
+			DeviceServiceURL:             "http://edgex-device-llrp:49989/",
 			MetadataServiceURL:           "http://edgex-core-metadata:48081/",
 			DepartedThresholdSeconds:     600,
 			DepartedCheckIntervalSeconds: 30,

--- a/internal/inventory/config_test.go
+++ b/internal/inventory/config_test.go
@@ -86,7 +86,7 @@ func TestParseConsulConfig(t *testing.T) {
 		{key: "DeviceServiceName", val: "", exp: ""},
 		{key: "DeviceServiceName", val: " ", exp: " "},
 
-		{key: "DeviceServiceURL", val: "http://testing:51992/", exp: "http://testing:51992/"},
+		{key: "DeviceServiceURL", val: "http://testing:49989/", exp: "http://testing:49989/"},
 		{key: "DeviceServiceURL", val: "", exp: ""},
 		{key: "MetadataServiceURL", val: "", exp: ""},
 	}

--- a/internal/inventory/event.go
+++ b/internal/inventory/event.go
@@ -9,31 +9,43 @@ type EventType string
 
 const (
 	// note: these values are also used when creating the EdgeX event names
+
 	ArrivedType  EventType = "Arrived"
 	MovedType    EventType = "Moved"
 	DepartedType EventType = "Departed"
 )
 
+type BaseEvent struct {
+	// EPC stands for Electronic Product Code. EPC was designed as a universal identifier
+	// system to provides a unique identity for every physical object in the world.
+	EPC string `json:"epc"`
+	// TID is commonly referred to as Tag ID or Transponder ID. It is a unique number written to
+	// every RFID tag by the manufacturer and is non-writable.
+	TID string `json:"tid"`
+	// Timestamp is the time at which this event occurred. It represents milliseconds
+	// since the Unix Epoch.
+	Timestamp int64 `json:"timestamp"`
+}
+
 type ArrivedEvent struct {
-	EPC       string `json:"epc"`
-	TID       string `json:"tid"`
-	Timestamp int64  `json:"timestamp"`
-	Location  string `json:"location"`
+	BaseEvent
+	// Location is the location at which the Arrived event occurred.
+	Location string `json:"location"`
 }
 
 type MovedEvent struct {
-	EPC         string `json:"epc"`
-	TID         string `json:"tid"`
-	Timestamp   int64  `json:"timestamp"`
+	BaseEvent
+	// OldLocation is the previous location at which the tag resided before it moved.
 	OldLocation string `json:"old_location"`
+	// NewLocation is the current location of the tag after the Moved event.
 	NewLocation string `json:"new_location"`
 }
 
 type DepartedEvent struct {
-	EPC               string `json:"epc"`
-	TID               string `json:"tid"`
-	Timestamp         int64  `json:"timestamp"`
-	LastRead          int64  `json:"last_read"`
+	BaseEvent
+	// LastRead is the last time in which this tag was read (Unix Epoch milliseconds).
+	LastRead int64 `json:"last_read"`
+	// LastKnownLocation is the location that the tag was associated with before it Departed.
 	LastKnownLocation string `json:"last_known_location"`
 }
 

--- a/internal/inventory/location.go
+++ b/internal/inventory/location.go
@@ -1,0 +1,34 @@
+//
+// Copyright (C) 2021 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package inventory
+
+import "strconv"
+
+// Location represents a unique Device-Antenna combination
+type Location struct {
+	// DeviceName is the name of the device which corresponds to the antenna where the
+	// tag is located
+	DeviceName string `json:"device_name"`
+	// AntennaID is the id number of the antenna as reported by LLRP and is unique/relative to the
+	// device it is attached to.
+	AntennaID uint16 `json:"antenna_id"`
+}
+
+func NewLocation(deviceName string, antennaID uint16) Location {
+	return Location{DeviceName: deviceName, AntennaID: antennaID}
+}
+
+func (loc Location) Equals(other Location) bool {
+	return loc.AntennaID == other.AntennaID && loc.DeviceName == other.DeviceName
+}
+
+func (loc Location) IsEmpty() bool {
+	return loc.DeviceName == "" && loc.AntennaID == 0
+}
+
+func (loc Location) String() string {
+	return loc.DeviceName + "_" + strconv.Itoa(int(loc.AntennaID))
+}

--- a/internal/inventory/statictag.go
+++ b/internal/inventory/statictag.go
@@ -1,0 +1,69 @@
+//
+// Copyright (C) 2021 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package inventory
+
+// StaticTag represents a Tag object stuck in time for use with APIs
+type StaticTag struct {
+	// EPC stands for Electronic Product Code. EPC was designed as a universal identifier
+	// system to provides a unique identity for every physical object in the world.
+	EPC string `json:"epc"`
+	// TID is commonly referred to as Tag ID or Transponder ID. It is a unique number written to
+	// every RFID tag by the manufacturer and is non-writable.
+	TID string `json:"tid"`
+	// Location keeps track of the tag's current location in the form of Device and Antenna combo.
+	Location Location `json:"location"`
+	// LocationAlias returns the string version of the location adjusted for any user-provided aliases.
+	LocationAlias string `json:"location_alias"`
+	// LastRead keeps track of the last time the tag was seen by any reader/antenna
+	// (Unix Epoch milliseconds). This value is used to determine AgeOut as
+	// well as Departed events.
+	LastRead int64 `json:"last_read"`
+	// LastArrived keeps track of the most recent time this tag generated an ArrivedEvent.
+	// (Unix Epoch milliseconds).
+	LastArrived int64 `json:"last_arrived"`
+	// LastArrived keeps track of the most recent time this tag generated an ArrivedEvent.
+	// (Unix Epoch milliseconds).
+	LastDeparted int64 `json:"last_departed"`
+	// State is the current state of the tag (Present, Departed, Unknown)
+	State TagState `json:"state"`
+	// StatsMap keeps track of read statistics on a per-antenna basis in order to apply
+	// tag location algorithms against.
+	StatsMap map[string]StaticTagStats `json:"stats_map"`
+}
+
+// StaticTagStats represents a tagStats object stuck in time for use with APIs
+// and includes pre-calculated data
+type StaticTagStats struct {
+	LastRead int64   `json:"last_read"`
+	MeanRSSI float64 `json:"mean_rssi"`
+}
+
+// asTagPtr converts a StaticTag back to a Tag pointer for use in restoring inventory.
+// It will also restore a basic view of the per-location stats by setting the last read
+// timestamp and a single RSSI value which was the previously computed rolling average.
+func (s StaticTag) asTagPtr() *Tag {
+	t := &Tag{
+		EPC:          s.EPC,
+		TID:          s.TID,
+		Location:     s.Location,
+		LastRead:     s.LastRead,
+		LastDeparted: s.LastDeparted,
+		LastArrived:  s.LastArrived,
+		state:        s.State,
+		statsMap:     make(map[string]*tagStats),
+	}
+
+	// fill in any cached tag stats. this just adds the mean rssi as a single value,
+	// so some precision is lost by not having every single value, but it preserves
+	// a general view of the data which is good enough for now
+	for location, stats := range s.StatsMap {
+		tagStats := t.getStats(location)
+		tagStats.lastRead = stats.LastRead
+		tagStats.rssiDbm.AddValue(stats.MeanRSSI)
+	}
+
+	return t
+}

--- a/internal/inventory/tagstats.go
+++ b/internal/inventory/tagstats.go
@@ -9,31 +9,31 @@ const (
 	tagStatsWindowSize = 20
 )
 
-// TagStats helps keep track of tag read rssi values over time
-type TagStats struct {
-	LastRead int64
-	rssiDbm  *CircularBuffer
+// tagStats helps keep track of tag read rssi values over time
+type tagStats struct {
+	lastRead int64
+	rssiDbm  *circularBuffer
 }
 
-// NewTagStats returns a new TagStats pointer with circular buffers initialized to the configured default window size
-func NewTagStats() *TagStats {
-	return &TagStats{
-		rssiDbm: NewCircularBuffer(tagStatsWindowSize),
+// newTagStats returns a new tagStats pointer with circular buffers initialized to the configured default window size
+func newTagStats() *tagStats {
+	return &tagStats{
+		rssiDbm: newCircularBuffer(tagStatsWindowSize),
 	}
 }
 
-func (stats *TagStats) updateRSSI(rssi float64) {
+func (stats *tagStats) updateRSSI(rssi float64) {
 	stats.rssiDbm.AddValue(rssi)
 }
 
-func (stats *TagStats) updateLastRead(lastRead int64) {
+func (stats *tagStats) updateLastRead(lastRead int64) {
 	// skip times that are at or before the current last read timestamp
-	if lastRead <= stats.LastRead {
+	if lastRead <= stats.lastRead {
 		return
 	}
-	stats.LastRead = lastRead
+	stats.lastRead = lastRead
 }
 
-func (stats *TagStats) rssiCount() int {
+func (stats *tagStats) rssiCount() int {
 	return stats.rssiDbm.Len()
 }

--- a/internal/llrp/util.go
+++ b/internal/llrp/util.go
@@ -1,0 +1,67 @@
+//
+// Copyright (C) 2021 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package llrp
+
+import "encoding/binary"
+
+const hexChars = "0123456789abcdef"
+
+// wordsToHex converts an array of 16-bit words to a hex string.
+//
+// This is essentially the same method as hex.EncodeToString,
+// but operates on []uint16 instead of []byte.
+func wordsToHex(src []uint16) string {
+	dst := make([]byte, len(src)*4)
+
+	i := 0
+	for _, word := range src {
+		dst[i+0] = hexChars[(word>>0xC)&0xF]
+		dst[i+1] = hexChars[(word>>0x8)&0xF]
+		dst[i+2] = hexChars[(word>>0x4)&0xF]
+		dst[i+3] = hexChars[(word>>0x0)&0xF]
+		i += 4
+	}
+
+	return string(dst)
+}
+
+// ExtractRSSI returns the RSSI value from TagReportData, if present.
+//
+// If the report includes a Custom Impinj RSSI parameter, it returns that.
+// Because those values are dBm x100, it converts it to dBm (by dividing by 100),
+// and hence the returned value is a floats instead of an int.
+func (rt *TagReportData) ExtractRSSI() (float64, bool) {
+	for _, c := range rt.Custom {
+		if c.Is(PENImpinj, ImpinjEnablePeakRSSI) && len(c.Data) == 2 {
+			return float64(binary.BigEndian.Uint16(c.Data)) / 100.0, true // dBm x100
+		}
+	}
+
+	if rt.PeakRSSI != nil {
+		return float64(*rt.PeakRSSI), true
+	}
+	return 0, false
+}
+
+// ReadDataAsHex returns a hex string representation of a ReadOpSpecResult
+// if the TagReportData has one and its result type indicates success.
+func (rt *TagReportData) ReadDataAsHex() (data string, ok bool) {
+	if rt.C1G2ReadOpSpecResult == nil {
+		return
+	}
+
+	res := rt.C1G2ReadOpSpecResult
+	if res.C1G2ReadOpSpecResultType == 0 {
+		data = wordsToHex(res.Data)
+	}
+
+	return
+}
+
+// Is returns true if the Custom receiver is the specified Vendor and Subtype.
+func (c *Custom) Is(idType VendorPEN, subtype CustomParamSubtype) bool {
+	return VendorPEN(c.VendorID) == idType && c.Subtype == subtype
+}

--- a/internal/llrp/util_test.go
+++ b/internal/llrp/util_test.go
@@ -1,0 +1,6 @@
+//
+// Copyright (C) 2021 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package llrp

--- a/internal/llrp/vendors.go
+++ b/internal/llrp/vendors.go
@@ -7,8 +7,7 @@
 
 package llrp
 
-import "encoding/binary"
-
+// VendorPEN are constants that represent common known Private Enterprise Numbers
 type VendorPEN uint32
 
 const (
@@ -17,6 +16,7 @@ const (
 	PENZebra  = VendorPEN(10642)
 )
 
+// ImpinjModel are mappings for known Impinj model numbers to their model names.
 type ImpinjModel uint32
 
 const (
@@ -31,22 +31,24 @@ const (
 	R700         = ImpinjModel(2001052)
 )
 
-func (c *Custom) Is(idType VendorPEN, subtype uint32) bool {
-	return VendorPEN(c.VendorID) == idType && c.Subtype == subtype
-}
+// CustomParamSubtype is a base type for all custom param subtypes
+type CustomParamSubtype = uint32
 
-type ImpinjParamSubtype = uint32
-
-// impinjSearchMode is like a really limited version of standard state-aware filtering
-// with added ambiguity about what C1G2 commands the Reader might send.
-type impinjSearchMode = uint16
+// ImpinjParamSubtype are constant definitions of Impinj specific custom functionality
+type ImpinjParamSubtype = CustomParamSubtype
 
 const (
 	ImpinjEnablePeakRSSI           = ImpinjParamSubtype(53)
 	ImpinjPeakRSSI                 = ImpinjParamSubtype(57)
 	ImpinjTagReportContentSelector = ImpinjParamSubtype(50)
 	ImpinjSearchMode               = ImpinjParamSubtype(23)
+)
 
+// impinjSearchMode is like a really limited version of standard state-aware filtering
+// with added ambiguity about what C1G2 commands the Reader might send.
+type impinjSearchMode = uint16
+
+const (
 	// impSearchReaderSelected is the "default" search mode.
 	// There's no way to know exactly what it will do.
 	impSearchReaderSelected = impinjSearchMode(0)
@@ -116,58 +118,3 @@ const (
 	// high-throughput [with] repeated observation".
 	impjDualTargetWithReset = impinjSearchMode(6)
 )
-
-// ExtractRSSI returns the RSSI value from TagReportData, if present.
-//
-// If the report includes a Custom Impinj RSSI parameter, it returns that.
-// Because those values are dBm x100, it converts it to dBm (by dividing by 100),
-// and hence the returned value is a floats instead of an int.
-func (rt *TagReportData) ExtractRSSI() (rssi float64, ok bool) {
-	for _, c := range rt.Custom {
-		if c.Is(PENImpinj, ImpinjEnablePeakRSSI) && len(c.Data) == 2 {
-			return float64(binary.BigEndian.Uint16(c.Data)) / 100.0, true // dBm x100
-		}
-	}
-
-	if rt.PeakRSSI != nil {
-		rssi = float64(*rt.PeakRSSI)
-		ok = true
-	}
-	return
-}
-
-// ReadDataAsHex returns a hex string representation of a ReadOpSpecResult
-// if the TagReportData has one and its result type indicates success.
-func (rt *TagReportData) ReadDataAsHex() (data string, ok bool) {
-	if rt.C1G2ReadOpSpecResult == nil {
-		return
-	}
-
-	res := rt.C1G2ReadOpSpecResult
-	if res.C1G2ReadOpSpecResultType == 0 {
-		data = wordsToHex(res.Data)
-	}
-
-	return
-}
-
-const hexChars = "0123456789abcdef"
-
-// wordsToHex converts an array of 16-bit words to a hex string.
-//
-// This is essentially the same method as hex.EncodeToString,
-// but operates on []uint16 instead of []byte.
-func wordsToHex(src []uint16) string {
-	dst := make([]byte, len(src)*4)
-
-	i := 0
-	for _, word := range src {
-		dst[i+0] = hexChars[(word>>0xC)&0xF]
-		dst[i+1] = hexChars[(word>>0x8)&0xF]
-		dst[i+2] = hexChars[(word>>0x4)&0xF]
-		dst[i+3] = hexChars[(word>>0x0)&0xF]
-		i += 4
-	}
-
-	return string(dst)
-}

--- a/internal/logutil/logwrap.go
+++ b/internal/logutil/logwrap.go
@@ -1,0 +1,49 @@
+//
+// Copyright (C) 2021 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package logutil
+
+import (
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+	"os"
+)
+
+type LogWrap struct {
+	logger.LoggingClient
+}
+
+type KeyValue struct {
+	Key string
+	Val interface{}
+}
+
+func (lgr LogWrap) ErrIf(cond bool, msg string, params ...KeyValue) bool {
+	if !cond {
+		return false
+	}
+
+	if len(params) > 0 {
+		parts := make([]interface{}, len(params)*2)
+		for i := range params {
+			parts[i*2] = params[i].Key
+			parts[i*2+1] = params[i].Val
+		}
+		lgr.Error(msg, parts...)
+	} else {
+		lgr.Error(msg)
+	}
+
+	return true
+}
+
+func (lgr LogWrap) ExitIf(cond bool, msg string, params ...KeyValue) {
+	if lgr.ErrIf(cond, msg, params...) {
+		os.Exit(1)
+	}
+}
+
+func (lgr LogWrap) ExitIfErr(err error, msg string, params ...KeyValue) {
+	lgr.ExitIf(err != nil, msg, append(params, KeyValue{"error", err})...)
+}

--- a/res/configuration.toml
+++ b/res/configuration.toml
@@ -45,7 +45,7 @@ PublishTopic="events"
 
 [ApplicationSettings]
 DeviceServiceName = "edgex-device-rfid-llrp"
-DeviceServiceURL = "http://localhost:51992/"
+DeviceServiceURL = "http://localhost:49989/"
 MetadataServiceURL = "http://localhost:48081/"
 AdjustLastReadOnByOrigin = "true"
 DepartedThresholdSeconds = "600"

--- a/static/html/index.html
+++ b/static/html/index.html
@@ -118,7 +118,7 @@
 </nav>
 
 <div id="content" style="height: 100%">
-  <div class="b"><button type="button" class="btn btn-primary" onclick="call('POST', 'http://localhost:51992/api/v1/discovery')">Discover Readers</button></div>
+  <div class="b"><button type="button" class="btn btn-primary" onclick="call('POST', 'http://localhost:49989/api/v1/discovery')">Discover Readers</button></div>
   <div class="b"><button type="button" class="btn btn-primary" onclick="call('GET', '/api/v1/readers')">List Readers</button></div>
   <div class="b"><button type="button" class="btn btn-primary" onclick="call('GET', '/api/v1/behaviors/default')">Show Default Behavior</button></div>
   <div class="b"><button type="button" class="btn btn-primary" onclick="setDeepScan()">Set Deep Scan Behavior</button></div>


### PR DESCRIPTION
https://github.com/edgexfoundry-holding/rfid-llrp-inventory-service/pull/18#discussion_r595519578
https://github.com/edgexfoundry-holding/rfid-llrp-inventory-service/pull/18#discussion_r595523551
https://github.com/edgexfoundry-holding/rfid-llrp-inventory-service/pull/18#discussion_r595524138
https://github.com/edgexfoundry-holding/rfid-llrp-inventory-service/pull/18#discussion_r595525260
https://github.com/edgexfoundry-holding/rfid-llrp-inventory-service/pull/18#discussion_r595572991
https://github.com/edgexfoundry-holding/rfid-llrp-inventory-service/pull/18#discussion_r595575088
https://github.com/edgexfoundry-holding/rfid-llrp-inventory-service/pull/18#pullrequestreview-613781892
https://github.com/edgexfoundry-holding/rfid-llrp-inventory-service/pull/18#discussion_r595588978

Signed-off-by: Anthony Casagrande <anthony.j.casagrande@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [X] No

## Are there any new imports or modules? If so, what are they used for and why?
No

## Are there any specific instructions or things that should be known prior to reviewing?
No

## Other information
N/A
