### PR TITLE
Code Review Changes addressing unit test case comments

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,4 +9,5 @@ require (
 	github.com/edgexfoundry/go-mod-core-contracts v0.1.112
 	github.com/gorilla/mux v1.8.0
 	github.com/pkg/errors v0.9.1
+	github.com/stretchr/testify v1.6.1
 )

--- a/internal/inventory/circularbuffer_test.go
+++ b/internal/inventory/circularbuffer_test.go
@@ -9,6 +9,8 @@ import (
 	"fmt"
 	"math"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 var (
@@ -17,9 +19,7 @@ var (
 )
 
 func assertBufferSize(t *testing.T, buff *circularBuffer, expectedSize int) {
-	if buff.Len() != expectedSize {
-		t.Errorf("expected buffer size of %d, but was %d", buff.Len(), expectedSize)
-	}
+	assert.Equalf(t, buff.Len(), expectedSize, "expected buffer size of %d, but was %d", buff.Len(), expectedSize)
 }
 
 func TestCircularBuffer_AddValue(t *testing.T) {
@@ -89,9 +89,7 @@ func TestCircularBuffer_GetMean(t *testing.T) {
 			}
 
 			mean := buff.Mean()
-			if math.Abs(mean-test.expected) > epsilon {
-				t.Errorf("expected mean of %v, but got %v", test.expected, mean)
-			}
+			assert.LessOrEqualf(t, math.Abs(mean-test.expected), epsilon, "expected mean of %v, but got %v", test.expected, mean)
 		})
 	}
 }
@@ -134,9 +132,7 @@ func TestCircularBuffer_GetCount(t *testing.T) {
 			}
 
 			count := buff.Len()
-			if count != test.expectedCount {
-				t.Errorf("buff.Len() returned %d, but we expected %d", count, test.expectedCount)
-			}
+			assert.Equalf(t, count, test.expectedCount, "buff.Len() returned %d, but we expected %d", count, test.expectedCount)
 		})
 	}
 }
@@ -151,9 +147,7 @@ func TestCircularBuffer_Wrap(t *testing.T) {
 		val := float64(i * 2)
 		buff.AddValue(val)
 		assertBufferSize(t, buff, int(math.Min(float64(i+1), float64(windowSize))))
-		if buff.values[i%windowSize] != val {
-			t.Errorf("A value was added in the wrong location!")
-		}
+		assert.Equal(t, buff.values[i%windowSize], val, "A value was added in the wrong location!")
 	}
 	assertBufferSize(t, buff, windowSize)
 }

--- a/internal/inventory/epoch_helper_test.go
+++ b/internal/inventory/epoch_helper_test.go
@@ -41,7 +41,5 @@ func TestUnixMilli(t *testing.T) {
 func TestUnixMilliCalculation(t *testing.T) {
 	expectedMs := int64(1502472327865)
 	calcMs := UnixMilli(time.Unix(expectedMs/1000, expectedMs%1000*1000000))
-	fmt.Println(calcMs)
-	fmt.Println(expectedMs)
 	assert.Equal(t, calcMs, expectedMs, "Time to epoch calculation failed")
 }

--- a/internal/inventory/epoch_helper_test.go
+++ b/internal/inventory/epoch_helper_test.go
@@ -9,21 +9,22 @@ import (
 	"fmt"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestUnixMilli(t *testing.T) {
 	var target time.Time
 
+	assert := assert.New(t)
+
 	ms := UnixMilli(target)
-	if ms != 0 {
-		t.Error("Initial time should be empty")
-	}
+
+	assert.NotEqual(ms, 0, "Initial time should be empty")
 
 	target = time.Now()
 	ms = UnixMilli(target)
-	if ms == 0 {
-		t.Error("Initial time should NOT be empty")
-	}
+	assert.NotEqual(ms, 0, "Initial time should NOT be empty")
 
 	target = time.Now()
 	time.Sleep(30 * time.Millisecond)
@@ -31,6 +32,7 @@ func TestUnixMilli(t *testing.T) {
 	ms2 := UnixMilliNow()
 
 	fmt.Printf("Time delta: %d\n", ms2-ms)
+
 	if ms2-ms < 25 || ms2-ms > 35 {
 		t.Error("Time calculation bad")
 	}
@@ -39,7 +41,7 @@ func TestUnixMilli(t *testing.T) {
 func TestUnixMilliCalculation(t *testing.T) {
 	expectedMs := int64(1502472327865)
 	calcMs := UnixMilli(time.Unix(expectedMs/1000, expectedMs%1000*1000000))
-	if calcMs != expectedMs {
-		t.Error("Time to epoch calculation failed")
-	}
+	fmt.Println(calcMs)
+	fmt.Println(expectedMs)
+	assert.Equal(t, calcMs, expectedMs, "Time to epoch calculation failed")
 }

--- a/internal/inventory/mobilityprofile_test.go
+++ b/internal/inventory/mobilityprofile_test.go
@@ -3,6 +3,8 @@ package inventory
 import (
 	"math"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestNewMobilityProfile_yIntercept(t *testing.T) {
@@ -19,9 +21,7 @@ func TestNewMobilityProfile_yIntercept(t *testing.T) {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
 			mp := newMobilityProfile(test.slope, test.threshold, test.holdoffMillis)
-			if math.Abs(mp.yIntercept-test.yIntercept) > epsilon {
-				t.Errorf("Expected yIntercept to be: %v, but was: %v.", test.yIntercept, mp.yIntercept)
-			}
+			assert.LessOrEqualf(t, math.Abs(mp.yIntercept-test.yIntercept), epsilon, "Expected yIntercept to be: %v, but was: %v.", test.yIntercept, mp.yIntercept)
 		})
 	}
 }

--- a/internal/inventory/tagprocessor_test.go
+++ b/internal/inventory/tagprocessor_test.go
@@ -7,9 +7,11 @@ package inventory
 
 import (
 	"fmt"
-	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	"testing"
 	"time"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+	"github.com/stretchr/testify/assert"
 )
 
 const (
@@ -136,10 +138,8 @@ func TestMoveAntennaLocation(t *testing.T) {
 				count:      4,
 			})
 
-			if tag.Location.String() != ds.findAlias(sensor, antID) {
-				t.Errorf("tag location was %s, but we expected %s.\n\t%#v",
-					tag.Location.String(), ds.findAlias(sensor, antID), tag)
-			}
+			assert.Equalf(t, tag.Location.String(), ds.findAlias(sensor, antID), "tag location was %s, but we expected %s.\n\t%#v", tag.Location.String(), ds.findAlias(sensor, antID), tag)
+
 			// ensure moved events generated
 			if err := ds.verifyEventPattern(events, 1, MovedType); err != nil {
 				t.Error(err)
@@ -207,10 +207,7 @@ func TestAgeOutTask_RequireDepartedState(t *testing.T) {
 
 	// should not remove any tags
 	ds.tp.AgeOut()
-	if len(ds.tp.inventory) != ds.size() {
-		t.Errorf("expected there to be %d items in the inventory, but there were %d.\ninventory: %#v",
-			ds.size(), len(ds.tp.inventory), ds.tp.inventory)
-	}
+	assert.Equalf(t, len(ds.tp.inventory), ds.size(), "expected there to be %d items in the inventory, but there were %d.\ninventory: %#v", ds.size(), len(ds.tp.inventory), ds.tp.inventory)
 
 	// now we will flag the items as departed and run the ageout task again
 	_, _ = ds.tp.AggregateDeparted()
@@ -219,10 +216,7 @@ func TestAgeOutTask_RequireDepartedState(t *testing.T) {
 	}
 	// this time they should be removed from the inventory
 	ds.tp.AgeOut()
-	if len(ds.tp.inventory) != 0 {
-		t.Errorf("expected there to be 0 items in the inventory, but there were %d.\ninventory: %#v",
-			len(ds.tp.inventory), ds.tp.inventory)
-	}
+	assert.Equalf(t, len(ds.tp.inventory), 0, "expected there to be 0 items in the inventory, but there were %d.\ninventory: %#v", len(ds.tp.inventory), ds.tp.inventory)
 }
 
 func TestAgeOutThreshold(t *testing.T) {
@@ -453,9 +447,7 @@ func TestReaderAntennaAliasDefault(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.expected, func(t *testing.T) {
 			alias := ds.findAlias(test.deviceID, test.antennaID)
-			if alias != test.expected {
-				t.Errorf("Expected alias of %s, but got %s", test.expected, alias)
-			}
+			assert.Equalf(t, alias, test.expected, "Expected alias of %s, but got %s", test.expected, alias)
 		})
 	}
 }
@@ -494,9 +486,7 @@ func TestReaderAntennaAliasExisting(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.expected, func(t *testing.T) {
 			alias := ds.findAlias(test.deviceID, test.antennaID)
-			if alias != test.expected {
-				t.Errorf("Expected alias of %s, but got %s", test.expected, alias)
-			}
+			assert.Equalf(t, alias, test.expected, "Expected alias of %s, but got %s", test.expected, alias)
 		})
 	}
 }
@@ -532,9 +522,7 @@ func TestEventLocationMatchesAlias(t *testing.T) {
 	// make sure the Location field matches the alias for Arrived events
 	for _, event := range events {
 		a := event.(ArrivedEvent)
-		if a.Location != alias1 {
-			t.Errorf("Expected arrived event location to be %s, but was %s", alias1, a.Location)
-		}
+		assert.Equalf(t, a.Location, alias1, "Expected arrived event location to be %s, but was %s", alias1, a.Location)
 	}
 
 	// Generate moved events alias1 -> alias2
@@ -552,12 +540,10 @@ func TestEventLocationMatchesAlias(t *testing.T) {
 	// make sure the 2 Location fields match the alias for Moved events
 	for _, event := range events {
 		m := event.(MovedEvent)
-		if m.OldLocation != alias1 {
-			t.Errorf("Expected moved event old location to be %s, but was %s", alias1, m.OldLocation)
-		}
-		if m.NewLocation != alias2 {
-			t.Errorf("Expected moved event new location to be %s, but was %s", alias2, m.NewLocation)
-		}
+		assert.Equalf(t, m.OldLocation, alias1, "Expected moved event old location to be %s, but was %s", alias1, m.OldLocation)
+
+		assert.Equalf(t, m.NewLocation, alias2, "Expected moved event new location to be %s, but was %s", alias2, m.NewLocation)
+
 	}
 
 	// Generate departed events
@@ -568,8 +554,7 @@ func TestEventLocationMatchesAlias(t *testing.T) {
 	// make sure the Location field matches the alias for Departed events
 	for _, event := range events {
 		d := event.(DepartedEvent)
-		if d.LastKnownLocation != alias2 {
-			t.Errorf("Expected departed event last known location to be %s, but was %s", alias2, d.LastKnownLocation)
-		}
+		assert.Equalf(t, d.LastKnownLocation, alias2, "Expected departed event last known location to be %s, but was %s", alias2, d.LastKnownLocation)
+
 	}
 }


### PR DESCRIPTION
## PR Type
- Other - Code Review Changes addressing following unit test case comments
- https://github.com/edgexfoundry-holding/rfid-llrp-inventory-service/pull/18#discussion_r588679718
- https://github.com/edgexfoundry-holding/rfid-llrp-inventory-service/pull/18#discussion_r588680778
- https://github.com/edgexfoundry-holding/rfid-llrp-inventory-service/pull/18#discussion_r588687308
- https://github.com/edgexfoundry-holding/rfid-llrp-inventory-service/pull/18#discussion_r588687854
- https://github.com/edgexfoundry-holding/rfid-llrp-inventory-service/pull/18#discussion_r588688327
- https://github.com/edgexfoundry-holding/rfid-llrp-inventory-service/pull/18#discussion_r588688594
- https://github.com/edgexfoundry-holding/rfid-llrp-inventory-service/pull/18#discussion_r588689065
- https://github.com/edgexfoundry-holding/rfid-llrp-inventory-service/pull/18#discussion_r588689917
- https://github.com/edgexfoundry-holding/rfid-llrp-inventory-service/pull/18#discussion_r588690950
- https://github.com/edgexfoundry-holding/rfid-llrp-inventory-service/pull/18#discussion_r588691279
- https://github.com/edgexfoundry-holding/rfid-llrp-inventory-service/pull/18#discussion_r588692205
- https://github.com/edgexfoundry-holding/rfid-llrp-inventory-service/pull/18#discussion_r588716116
- https://github.com/edgexfoundry-holding/rfid-llrp-inventory-service/pull/18#discussion_r588694504

## Are there any new imports or modules? If so, what are they used for and why?
Importing the following test package
github.com/stretchr/testify
