### PR TITLE
Add tests

### DIFF
--- a/Attribution.txt
+++ b/Attribution.txt
@@ -158,3 +158,6 @@ https://github.com/stretchr/testify/blob/master/LICENSE
 
 gopkg.in/yaml.v3 (Apache 2.0) https://github.com/go-yaml/yaml/tree/v3
 https://github.com/go-yaml/yaml/blob/v2/LICENSE
+
+go-playground/assert (MIT) github.com/go-playground/assert
+https://github.com/go-playground/assert/blob/master/LICENSE

--- a/Attribution.txt
+++ b/Attribution.txt
@@ -147,3 +147,14 @@ https://github.com/go-playground/validator/blob/master/LICENSE
 leodido/go-urn (MIT) https://github.com/leodido/go-urn
 https://github.com/leodido/go-urn
 
+davecgh/go-spew (ISC) https://github.com/davecgh/go-spew
+https://github.com/davecgh/go-spew/blob/master/LICENSE
+
+pmezard/go-difflib (Patric Mezard) https://github.com/pmezard/go-difflib
+https://github.com/pmezard/go-difflib/blob/master/LICENSE
+
+stretchr/testify (MIT) github.com/stretchr/testify
+https://github.com/stretchr/testify/blob/master/LICENSE
+
+gopkg.in/yaml.v3 (Apache 2.0) https://github.com/go-yaml/yaml/tree/v3
+https://github.com/go-yaml/yaml/blob/v2/LICENSE

--- a/Attribution.txt
+++ b/Attribution.txt
@@ -158,6 +158,3 @@ https://github.com/stretchr/testify/blob/master/LICENSE
 
 gopkg.in/yaml.v3 (Apache 2.0) https://github.com/go-yaml/yaml/tree/v3
 https://github.com/go-yaml/yaml/blob/v2/LICENSE
-
-go-playground/assert (MIT) github.com/go-playground/assert
-https://github.com/go-playground/assert/blob/master/LICENSE

--- a/go.mod
+++ b/go.mod
@@ -9,4 +9,5 @@ require (
 	github.com/edgexfoundry/go-mod-core-contracts v0.1.112
 	github.com/gorilla/mux v1.8.0
 	github.com/pkg/errors v0.9.1
+	github.com/stretchr/testify v1.7.0
 )

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/edgexfoundry/go-mod-bootstrap v0.0.57
 	github.com/edgexfoundry/go-mod-configuration v0.0.8
 	github.com/edgexfoundry/go-mod-core-contracts v0.1.112
+	github.com/go-playground/assert v1.2.1
 	github.com/gorilla/mux v1.8.0
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.7.0

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/edgexfoundry/go-mod-bootstrap v0.0.57
 	github.com/edgexfoundry/go-mod-configuration v0.0.8
 	github.com/edgexfoundry/go-mod-core-contracts v0.1.112
-	github.com/go-playground/assert v1.2.1
 	github.com/gorilla/mux v1.8.0
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.7.0

--- a/internal/inventory/config_test.go
+++ b/internal/inventory/config_test.go
@@ -117,7 +117,7 @@ func TestQuickCheckStr(t *testing.T) {
 			conf, parseErr := ParseConsulConfig(nil, map[string]string{
 				"DeviceServiceName": val})
 			return parseErr == nil && conf.ApplicationSettings.DeviceServiceName == val
-		}, nil);
+		}, nil)
 		require.NoError(tt, err)
 	})
 }
@@ -143,7 +143,7 @@ func TestQuickCheckUint(t *testing.T) {
 			iStr := strconv.FormatUint(uint64(u), 10)
 			conf, parseErr := ParseConsulConfig(nil, map[string]string{"AgeOutHours": iStr})
 			return parseErr == nil && conf.ApplicationSettings.AgeOutHours == u
-		}, nil);
+		}, nil)
 		require.NoError(tt, err)
 	})
 }
@@ -165,7 +165,7 @@ func TestQuickCheckFloat64(t *testing.T) {
 			}
 			return parseErr == nil && math.Abs(
 				conf.ApplicationSettings.MobilityProfileThreshold-f) < 0.001
-		}, nil);
+		}, nil)
 		require.NoError(tt, err)
 	})
 }

--- a/internal/inventory/config_test.go
+++ b/internal/inventory/config_test.go
@@ -6,7 +6,7 @@
 package inventory
 
 import (
-	"github.com/stretchr/testify/require"
+	"errors"
 	"math"
 	"reflect"
 	"strconv"
@@ -16,10 +16,15 @@ import (
 
 func TestEmptyConfigDefaults(t *testing.T) {
 	conf, err := ParseConsulConfig(getTestingLogger(), map[string]string{})
-	require.NoError(t, err)
+	if err != nil {
+		t.Fatalf("unexpected err: %+v", err.Error())
+	}
 
 	expected := NewConsulConfig()
-	require.Equal(t, expected, conf)
+	if !reflect.DeepEqual(expected, conf) {
+		t.Errorf("expected defaults, but got %+v; defaults: %+v",
+			expected, conf)
+	}
 }
 
 func TestParseConsulConfig(t *testing.T) {
@@ -92,70 +97,68 @@ func TestParseConsulConfig(t *testing.T) {
 		t.Run(c.key+":"+c.val, func(tt *testing.T) {
 			cfgMap := map[string]string{c.key: c.val}
 			ccfg, err := ParseConsulConfig(getTestingLogger(), cfgMap)
-			require.ErrorIs(t, err, c.err)
+			if !errors.Is(err, c.err) {
+				tt.Fatalf("expected %v, but got %+v", c.err, err)
+			}
+
 			if c.err != nil {
 				return
 			}
 
 			ft, ok := rt.FieldByName(c.key)
-			require.True(t, ok)
+			if !ok {
+				tt.Fatalf("no field %q", c.key)
+			}
 
 			rv := reflect.ValueOf(ccfg.ApplicationSettings)
 			fv := rv.FieldByIndex(ft.Index)
-			require.True(t, fv.IsValid())
-			require.True(t, fv.CanInterface())
-			require.Equal(t, fv.Interface(), c.exp)
+
+			if !fv.IsValid() || !fv.CanInterface() {
+				tt.Errorf("value of %q is not valid", c.key)
+				return
+			}
+
+			if !reflect.DeepEqual(fv.Interface(), c.exp) {
+				tt.Errorf("invalid value for %q: expected %+v, got %+v",
+					c.key, c.exp, fv.Interface())
+			}
 		})
 	}
-}
 
-func TestQuickCheckStr(t *testing.T) {
 	// quick.Check that we return an error (and don't panic) on arbitrary strings.
 	t.Run("quickCheckStr", func(tt *testing.T) {
 		tt.Parallel()
-		err := quick.Check(func(val string) bool {
+		if err := quick.Check(func(val string) bool {
 			conf, parseErr := ParseConsulConfig(nil, map[string]string{
 				"DeviceServiceName": val})
 			return parseErr == nil && conf.ApplicationSettings.DeviceServiceName == val
-		}, nil)
-		require.NoError(tt, err)
+		}, nil); err != nil {
+			tt.Error(err)
+		}
 	})
-}
 
-func TestQuickCheckUint(t *testing.T) {
 	// quick.Check that we can round-trip arbitrary uints.
 	t.Run("quickCheckUint", func(tt *testing.T) {
 		tt.Parallel()
-		//if err := quick.Check(func(u uint) bool {
-		//	if u == 0 {
-		//		return true
-		//	}
-		//	iStr := strconv.FormatUint(uint64(u), 10)
-		//	conf, parseErr := ParseConsulConfig(nil, map[string]string{"AgeOutHours": iStr})
-		//	return parseErr == nil && conf.ApplicationSettings.AgeOutHours == u
-		//}, nil); err != nil {
-		//	t.Error(err)
-		//}
-		err := quick.Check(func(u uint) bool {
+		if err := quick.Check(func(u uint) bool {
 			if u == 0 {
 				return true
 			}
 			iStr := strconv.FormatUint(uint64(u), 10)
 			conf, parseErr := ParseConsulConfig(nil, map[string]string{"AgeOutHours": iStr})
 			return parseErr == nil && conf.ApplicationSettings.AgeOutHours == u
-		}, nil)
-		require.NoError(tt, err)
+		}, nil); err != nil {
+			t.Error(err)
+		}
 	})
-}
 
-func TestQuickCheckFloat64(t *testing.T) {
 	// quick.Check that we can round-trip arbitrary float64s.
 	t.Run("quickCheckFloat64", func(tt *testing.T) {
 		tt.Parallel()
 		// Note: FormatFloat can produce binary values (with 'b'),
 		// but ParseFloat can't parse them, so it's not in this list.
 		fmts := [...]byte{'e', 'E', 'f', 'g', 'G', 'x', 'X'}
-		err := quick.Check(func(f float64, fmtByte byte) bool {
+		if err := quick.Check(func(f float64, fmtByte byte) bool {
 			iStr := strconv.FormatFloat(f, fmts[int(fmtByte)%len(fmts)], -1, 64)
 			conf, parseErr := ParseConsulConfig(nil, map[string]string{
 				"MobilityProfileThreshold": iStr})
@@ -165,7 +168,8 @@ func TestQuickCheckFloat64(t *testing.T) {
 			}
 			return parseErr == nil && math.Abs(
 				conf.ApplicationSettings.MobilityProfileThreshold-f) < 0.001
-		}, nil)
-		require.NoError(tt, err)
+		}, nil); err != nil {
+			t.Error(err)
+		}
 	})
 }

--- a/internal/inventory/tag_test.go
+++ b/internal/inventory/tag_test.go
@@ -1,7 +1,7 @@
 package inventory
 
 import (
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
@@ -27,7 +27,7 @@ func TestNewTag(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := NewTag(tt.args.epc)
-			require.Equal(t, got, tt.want)
+			assert.Equal(t, got, tt.want)
 		})
 	}
 }
@@ -68,7 +68,7 @@ func TestSetState(t *testing.T) {
 				state:    tt.fields.state,
 			}
 			tag.setState(tt.args.newState)
-			require.Equal(t, tt.args.newState, tag.state)
+			assert.Equal(t, tt.args.newState, tag.state)
 		})
 	}
 }
@@ -117,9 +117,9 @@ func TestSetStateAt(t *testing.T) {
 				state:        tt.fields.state,
 			}
 			tag.setStateAt(tt.args.newState, tt.args.timestamp)
-			require.Equal(t, tag.state, tt.args.newState)
-			require.Equal(t, tag.LastArrived, tt.args.timestamp)
-			require.Equal(t, tag.LastDeparted, tt.args.timestamp)
+			assert.Equal(t, tag.state, tt.args.newState)
+			assert.Equal(t, tag.LastArrived, tt.args.timestamp)
+			assert.Equal(t, tag.LastDeparted, tt.args.timestamp)
 		})
 	}
 }
@@ -149,7 +149,7 @@ func TestResetStats(t *testing.T) {
 				statsMap: tt.fields.statsMap,
 			}
 			tag.resetStats()
-			require.Equal(t, tag.statsMap, make(map[string]*tagStats))
+			assert.Equal(t, tag.statsMap, make(map[string]*tagStats))
 		})
 	}
 }
@@ -190,7 +190,7 @@ func TestGetStats(t *testing.T) {
 				statsMap: tt.fields.statsMap,
 			}
 			got := tag.getStats(tt.args.location)
-			require.Equal(t, got, tt.want)
+			assert.Equal(t, got, tt.want)
 		})
 	}
 }

--- a/internal/inventory/tag_test.go
+++ b/internal/inventory/tag_test.go
@@ -1,0 +1,196 @@
+package inventory
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func tagHelper(epc string, state TagState) *Tag {
+	return &Tag{EPC: "test", state: TagState(state), statsMap: make(map[string]*tagStats)}
+}
+
+func TestNewTag(t *testing.T) {
+	type args struct {
+		epc string
+	}
+	tests := []struct {
+		name string
+		args args
+		want *Tag
+	}{
+		{
+			name: "OK",
+			args: args{epc: "test"},
+			want: tagHelper("test", TagState(Unknown)),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NewTag(tt.args.epc)
+			require.Equal(t, got, tt.want)
+		})
+	}
+}
+
+func TestSetState(t *testing.T) {
+	type fields struct {
+		LastRead int64
+		state    TagState
+	}
+	type args struct {
+		newState TagState
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+	}{
+		{
+			name:   "OK - change to Unknown state",
+			fields: fields{state: TagState(Present), LastRead: 9999999999},
+			args:   args{newState: TagState(Unknown)},
+		},
+		{
+			name:   "OK - change to Departed state",
+			fields: fields{state: TagState(Present), LastRead: 9999999999},
+			args:   args{newState: TagState(Departed)},
+		},
+		{
+			name:   "OK - maintain Unknown state",
+			fields: fields{state: TagState(Unknown), LastRead: 9999999999},
+			args:   args{newState: TagState(Unknown)},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tag := &Tag{
+				LastRead: tt.fields.LastRead,
+				state:    tt.fields.state,
+			}
+			tag.setState(tt.args.newState)
+			require.Equal(t, tt.args.newState, tag.state)
+		})
+	}
+}
+
+func TestSetStateAt(t *testing.T) {
+	type fields struct {
+		LastDeparted int64
+		LastArrived  int64
+		state        TagState
+	}
+	type args struct {
+		newState  TagState
+		timestamp int64
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+	}{
+		{
+			name:   "OK - change to Present state",
+			fields: fields{state: Unknown, LastArrived: 9999999998, LastDeparted: 9999999999},
+			args:   args{newState: Present, timestamp: 9999999999},
+		},
+		{
+			name:   "OK - change to Departed state",
+			fields: fields{state: Unknown, LastDeparted: 9999999998, LastArrived: 9999999999},
+			args:   args{newState: Departed, timestamp: 9999999999},
+		},
+		{
+			name:   "OK - change to Unknown state",
+			fields: fields{state: Departed, LastDeparted: 9999999998, LastArrived: 9999999998},
+			args:   args{newState: Unknown, timestamp: 9999999998},
+		},
+		{
+			name:   "OK - maintain Unknown state",
+			fields: fields{state: Unknown, LastDeparted: 9999999998, LastArrived: 9999999998},
+			args:   args{newState: Unknown, timestamp: 9999999998},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tag := &Tag{
+				LastDeparted: tt.fields.LastDeparted,
+				LastArrived:  tt.fields.LastArrived,
+				state:        tt.fields.state,
+			}
+			tag.setStateAt(tt.args.newState, tt.args.timestamp)
+			require.Equal(t, tag.state, tt.args.newState)
+			require.Equal(t, tag.LastArrived, tt.args.timestamp)
+			require.Equal(t, tag.LastDeparted, tt.args.timestamp)
+		})
+	}
+}
+
+func TestResetStats(t *testing.T) {
+	type fields struct {
+		statsMap map[string]*tagStats
+	}
+	tests := []struct {
+		name   string
+		fields fields
+	}{
+		{
+			name:   "OK - nil case",
+			fields: fields{statsMap: nil},
+		},
+		{
+			name: "OK",
+			fields: fields{statsMap: map[string]*tagStats{
+				"test": newTagStats(),
+			}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tag := &Tag{
+				statsMap: tt.fields.statsMap,
+			}
+			tag.resetStats()
+			require.Equal(t, tag.statsMap, make(map[string]*tagStats))
+		})
+	}
+}
+
+func TestGetStats(t *testing.T) {
+	type fields struct {
+		statsMap map[string]*tagStats
+	}
+	type args struct {
+		location string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   *tagStats
+	}{
+		{
+			name: "OK - location found",
+			fields: fields{statsMap: map[string]*tagStats{
+				"test": newTagStats(),
+			}},
+			args: args{location: "test"},
+			want: newTagStats(),
+		},
+		{
+			name: "OK - location not found",
+			fields: fields{statsMap: map[string]*tagStats{
+				"test-location": newTagStats(),
+			}},
+			args: args{location: "wrong-location"},
+			want: newTagStats(),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tag := &Tag{
+				statsMap: tt.fields.statsMap,
+			}
+			got := tag.getStats(tt.args.location)
+			require.Equal(t, got, tt.want)
+		})
+	}
+}

--- a/internal/llrp/util.go
+++ b/internal/llrp/util.go
@@ -36,7 +36,7 @@ func wordsToHex(src []uint16) string {
 func (rt *TagReportData) ExtractRSSI() (float64, bool) {
 	for _, c := range rt.Custom {
 		if c.Is(PENImpinj, ImpinjEnablePeakRSSI) && len(c.Data) == 2 {
-			return float64(binary.BigEndian.Uint16(c.Data)) / 100.0, true // dBm x100
+			return float64(int16(binary.BigEndian.Uint16(c.Data))) / 100.0, true // dBm x100
 		}
 	}
 
@@ -56,6 +56,7 @@ func (rt *TagReportData) ReadDataAsHex() (data string, ok bool) {
 	res := rt.C1G2ReadOpSpecResult
 	if res.C1G2ReadOpSpecResultType == 0 {
 		data = wordsToHex(res.Data)
+		ok = true
 	}
 
 	return

--- a/internal/llrp/util_test.go
+++ b/internal/llrp/util_test.go
@@ -163,13 +163,8 @@ func TestExtractRSSI(t *testing.T) {
 				Custom:                                  tt.fields.Custom,
 			}
 			got, got1 := rt.ExtractRSSI()
-
-			if got != tt.want {
-				t.Errorf("ExtractRSSI() got = %v, want %v %d", got, tt.want, len(impinjEnableBool16(ImpinjTagReportContentSelector)))
-			}
-			if got1 != tt.want1 {
-				t.Errorf("ExtractRSSI() got1 = %v, want %v", got1, tt.want1)
-			}
+			require.Equal(t, got, tt.want)
+			require.Equal(t, got1, tt.want1)
 		})
 	}
 }
@@ -266,12 +261,8 @@ func TestReadDataAsHex(t *testing.T) {
 				Custom:                                  tt.fields.Custom,
 			}
 			gotData, gotOk := rt.ReadDataAsHex()
-			if gotData != tt.wantData {
-				t.Errorf("ReadDataAsHex() gotData = %v, want %v", gotData, tt.wantData)
-			}
-			if gotOk != tt.wantOk {
-				t.Errorf("ReadDataAsHex() gotOk = %v, want %v", gotOk, tt.wantOk)
-			}
+			require.Equal(t, gotData, tt.wantData)
+			require.Equal(t,gotOk, tt.wantOk)
 		})
 	}
 }
@@ -318,9 +309,7 @@ func TestIs(t *testing.T) {
 				Subtype:  tt.fields.Subtype,
 				Data:     tt.fields.Data,
 			}
-			if got := c.Is(tt.args.idType, tt.args.subtype); got != tt.want {
-				t.Errorf("Is() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, c.Is(tt.args.idType, tt.args.subtype), tt.want)
 		})
 	}
 }

--- a/internal/llrp/util_test.go
+++ b/internal/llrp/util_test.go
@@ -7,6 +7,7 @@ package llrp
 
 import (
 	"encoding/binary"
+	"github.com/go-playground/assert"
 	"github.com/stretchr/testify/require"
 	"testing"
 )
@@ -56,7 +57,7 @@ func TestWordsToHex(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			res := wordsToHex(tt.x)
-			require.Equal(t, tt.want, res)
+			assert.Equal(t, tt.want, res)
 		})
 	}
 }
@@ -163,13 +164,8 @@ func TestExtractRSSI(t *testing.T) {
 				Custom:                                  tt.fields.Custom,
 			}
 			got, got1 := rt.ExtractRSSI()
-
-			if got != tt.want {
-				t.Errorf("ExtractRSSI() got = %v, want %v %d", got, tt.want, len(impinjEnableBool16(ImpinjTagReportContentSelector)))
-			}
-			if got1 != tt.want1 {
-				t.Errorf("ExtractRSSI() got1 = %v, want %v", got1, tt.want1)
-			}
+			assert.Equal(t, got, tt.want)
+			assert.Equal(t, got1, tt.want1)
 		})
 	}
 }
@@ -265,8 +261,8 @@ func TestReadDataAsHex(t *testing.T) {
 				Custom:                                  tt.fields.Custom,
 			}
 			gotData, gotOk := rt.ReadDataAsHex()
-			require.Equal(t, gotData, tt.wantData)
 			require.Equal(t, gotOk, tt.wantOk)
+			assert.Equal(t, gotData, tt.wantData)
 		})
 	}
 }
@@ -314,7 +310,7 @@ func TestIs(t *testing.T) {
 				Data:     tt.fields.Data,
 			}
 			got := c.Is(tt.args.idType, tt.args.subtype)
-			require.Equal(t, got, tt.want)
+			assert.Equal(t, got, tt.want)
 		})
 	}
 }

--- a/internal/llrp/util_test.go
+++ b/internal/llrp/util_test.go
@@ -163,8 +163,13 @@ func TestExtractRSSI(t *testing.T) {
 				Custom:                                  tt.fields.Custom,
 			}
 			got, got1 := rt.ExtractRSSI()
-			require.Equal(t, got, tt.want)
-			require.Equal(t, got1, tt.want1)
+
+			if got != tt.want {
+				t.Errorf("ExtractRSSI() got = %v, want %v %d", got, tt.want, len(impinjEnableBool16(ImpinjTagReportContentSelector)))
+			}
+			if got1 != tt.want1 {
+				t.Errorf("ExtractRSSI() got1 = %v, want %v", got1, tt.want1)
+			}
 		})
 	}
 }
@@ -308,7 +313,8 @@ func TestIs(t *testing.T) {
 				Subtype:  tt.fields.Subtype,
 				Data:     tt.fields.Data,
 			}
-			require.Equal(t, c.Is(tt.args.idType, tt.args.subtype), tt.want)
+			got := c.Is(tt.args.idType, tt.args.subtype)
+			require.Equal(t, got, tt.want)
 		})
 	}
 }

--- a/internal/llrp/util_test.go
+++ b/internal/llrp/util_test.go
@@ -124,8 +124,8 @@ func TestExtractRSSI(t *testing.T) {
 		},
 		{
 			name:   "OK - custom",
-			fields: fields{Custom: []Custom{{VendorID: uint32(PENImpinj), Subtype: ImpinjEnablePeakRSSI, Data: []byte{'1','2'}}}},
-			want:   float64(int16(binary.BigEndian.Uint16([]byte{'1','2'}))) / 100.0,
+			fields: fields{Custom: []Custom{{VendorID: uint32(PENImpinj), Subtype: ImpinjEnablePeakRSSI, Data: []byte{'1', '2'}}}},
+			want:   float64(int16(binary.BigEndian.Uint16([]byte{'1', '2'}))) / 100.0,
 			want1:  true,
 		},
 	}
@@ -169,9 +169,8 @@ func TestExtractRSSI(t *testing.T) {
 	}
 }
 
-
-func helper()  *C1G2ReadOpSpecResult{
-	val := C1G2ReadOpSpecResult{C1G2ReadOpSpecResultType: 1, OpSpecID: impjDualTarget, Data: []uint16{1,2}}
+func helper() *C1G2ReadOpSpecResult {
+	val := C1G2ReadOpSpecResult{C1G2ReadOpSpecResultType: 1, OpSpecID: impjDualTarget, Data: []uint16{1, 2}}
 	return &val
 }
 
@@ -215,16 +214,16 @@ func TestReadDataAsHex(t *testing.T) {
 		wantOk   bool
 	}{
 		{
-			name: "OK - nil",
-			fields: fields{C1G2ReadOpSpecResult: nil},
+			name:     "OK - nil",
+			fields:   fields{C1G2ReadOpSpecResult: nil},
 			wantData: "",
-			wantOk: false,
+			wantOk:   false,
 		},
 		{
-			name: "OK - default values",
-			fields: fields{C1G2ReadOpSpecResult: new(C1G2ReadOpSpecResult)},
+			name:     "OK - default values",
+			fields:   fields{C1G2ReadOpSpecResult: new(C1G2ReadOpSpecResult)},
 			wantData: wordsToHex([]uint16{}),
-			wantOk: true,
+			wantOk:   true,
 		},
 	}
 	for _, tt := range tests {
@@ -262,7 +261,7 @@ func TestReadDataAsHex(t *testing.T) {
 			}
 			gotData, gotOk := rt.ReadDataAsHex()
 			require.Equal(t, gotData, tt.wantData)
-			require.Equal(t,gotOk, tt.wantOk)
+			require.Equal(t, gotOk, tt.wantOk)
 		})
 	}
 }

--- a/internal/llrp/util_test.go
+++ b/internal/llrp/util_test.go
@@ -7,7 +7,7 @@ package llrp
 
 import (
 	"encoding/binary"
-	"github.com/go-playground/assert"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"testing"
 )

--- a/internal/llrp/util_test.go
+++ b/internal/llrp/util_test.go
@@ -4,3 +4,323 @@
 // SPDX-License-Identifier: Apache-2.0
 
 package llrp
+
+import (
+	"encoding/binary"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestWordsToHex(t *testing.T) {
+	var tests = []struct {
+		name string
+		x    []uint16
+		want string
+	}{
+		{
+			name: "OK - empty",
+			x:    []uint16{},
+			want: "",
+		},
+		{
+			name: "OK - range: 0-7",
+			x:    []uint16{0, 1, 2, 3, 4, 5, 6, 7},
+			want: "00000001000200030004000500060007",
+		},
+		{
+			name: "OK - range: 8-15",
+			x:    []uint16{8, 9, 10, 11, 12, 13, 14, 15},
+			want: "00080009000a000b000c000d000e000f",
+		},
+		{
+			name: "OK- range: f0-f7",
+			x:    []uint16{0xf0, 0xf1, 0xf2, 0xf3, 0xf4, 0xf5, 0xf6, 0xf7},
+			want: "00f000f100f200f300f400f500f600f7",
+		},
+		{
+			name: "OK - range: f8-ff",
+			x:    []uint16{0xf8, 0xf9, 0xfa, 0xfb, 0xfc, 0xfd, 0xfe, 0xff},
+			want: "00f800f900fa00fb00fc00fd00fe00ff",
+		},
+		{
+			name: "OK - g",
+			x:    []uint16{'g'},
+			want: "0067",
+		},
+		{
+			name: "OK - range: e3, a1",
+			x:    []uint16{0xe3, 0xa1},
+			want: "00e300a1",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res := wordsToHex(tt.x)
+			require.Equal(t, tt.want, res)
+		})
+	}
+}
+
+func peakHelper(val float64) *PeakRSSI {
+	peak := PeakRSSI(val)
+	return &peak
+}
+
+func TestExtractRSSI(t *testing.T) {
+	type fields struct {
+		EPCData                                 EPCData
+		EPC96                                   EPC96
+		ROSpecID                                *ROSpecID
+		SpecIndex                               *SpecIndex
+		InventoryParameterSpecID                *InventoryParameterSpecID
+		AntennaID                               *AntennaID
+		PeakRSSI                                *PeakRSSI
+		ChannelIndex                            *ChannelIndex
+		FirstSeenUTC                            *FirstSeenUTC
+		FirstSeenUptime                         *FirstSeenUptime
+		LastSeenUTC                             *LastSeenUTC
+		LastSeenUptime                          *LastSeenUptime
+		TagSeenCount                            *TagSeenCount
+		C1G2PC                                  *C1G2PC
+		C1G2XPCW1                               *C1G2XPCW1
+		C1G2XPCW2                               *C1G2XPCW2
+		C1G2CRC                                 *C1G2CRC
+		AccessSpecID                            *AccessSpecID
+		C1G2ReadOpSpecResult                    *C1G2ReadOpSpecResult
+		C1G2WriteOpSpecResult                   *C1G2WriteOpSpecResult
+		C1G2KillOpSpecResult                    *C1G2KillOpSpecResult
+		C1G2LockOpSpecResult                    *C1G2LockOpSpecResult
+		C1G2BlockEraseOpSpecResult              *C1G2BlockEraseOpSpecResult
+		C1G2BlockWriteOpSpecResult              *C1G2BlockWriteOpSpecResult
+		C1G2RecommissionOpSpecResult            *C1G2RecommissionOpSpecResult
+		C1G2BlockPermalockOpSpecResult          *C1G2BlockPermalockOpSpecResult
+		C1G2GetBlockPermalockStatusOpSpecResult *C1G2GetBlockPermalockStatusOpSpecResult
+		ClientRequestOpSpecResult               *ClientRequestOpSpecResult
+		Custom                                  []Custom
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   float64
+		want1  bool
+	}{
+		{
+			name:   "OK",
+			fields: fields{PeakRSSI: new(PeakRSSI)},
+			want:   float64(0),
+			want1:  true,
+		},
+		{
+			name:   "OK - peak value",
+			fields: fields{PeakRSSI: peakHelper(3)},
+			want:   float64(3),
+			want1:  true,
+		},
+		{
+			name:   "OK - nil",
+			fields: fields{PeakRSSI: nil},
+			want:   float64(0),
+			want1:  false,
+		},
+		{
+			name:   "OK - custom",
+			fields: fields{Custom: []Custom{{VendorID: uint32(PENImpinj), Subtype: ImpinjEnablePeakRSSI, Data: []byte{'1','2'}}}},
+			want:   float64(int16(binary.BigEndian.Uint16([]byte{'1','2'}))) / 100.0,
+			want1:  true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rt := &TagReportData{
+				EPCData:                                 tt.fields.EPCData,
+				EPC96:                                   tt.fields.EPC96,
+				ROSpecID:                                tt.fields.ROSpecID,
+				SpecIndex:                               tt.fields.SpecIndex,
+				InventoryParameterSpecID:                tt.fields.InventoryParameterSpecID,
+				AntennaID:                               tt.fields.AntennaID,
+				PeakRSSI:                                tt.fields.PeakRSSI,
+				ChannelIndex:                            tt.fields.ChannelIndex,
+				FirstSeenUTC:                            tt.fields.FirstSeenUTC,
+				FirstSeenUptime:                         tt.fields.FirstSeenUptime,
+				LastSeenUTC:                             tt.fields.LastSeenUTC,
+				LastSeenUptime:                          tt.fields.LastSeenUptime,
+				TagSeenCount:                            tt.fields.TagSeenCount,
+				C1G2PC:                                  tt.fields.C1G2PC,
+				C1G2XPCW1:                               tt.fields.C1G2XPCW1,
+				C1G2XPCW2:                               tt.fields.C1G2XPCW2,
+				C1G2CRC:                                 tt.fields.C1G2CRC,
+				AccessSpecID:                            tt.fields.AccessSpecID,
+				C1G2ReadOpSpecResult:                    tt.fields.C1G2ReadOpSpecResult,
+				C1G2WriteOpSpecResult:                   tt.fields.C1G2WriteOpSpecResult,
+				C1G2KillOpSpecResult:                    tt.fields.C1G2KillOpSpecResult,
+				C1G2LockOpSpecResult:                    tt.fields.C1G2LockOpSpecResult,
+				C1G2BlockEraseOpSpecResult:              tt.fields.C1G2BlockEraseOpSpecResult,
+				C1G2BlockWriteOpSpecResult:              tt.fields.C1G2BlockWriteOpSpecResult,
+				C1G2RecommissionOpSpecResult:            tt.fields.C1G2RecommissionOpSpecResult,
+				C1G2BlockPermalockOpSpecResult:          tt.fields.C1G2BlockPermalockOpSpecResult,
+				C1G2GetBlockPermalockStatusOpSpecResult: tt.fields.C1G2GetBlockPermalockStatusOpSpecResult,
+				ClientRequestOpSpecResult:               tt.fields.ClientRequestOpSpecResult,
+				Custom:                                  tt.fields.Custom,
+			}
+			got, got1 := rt.ExtractRSSI()
+
+			if got != tt.want {
+				t.Errorf("ExtractRSSI() got = %v, want %v %d", got, tt.want, len(impinjEnableBool16(ImpinjTagReportContentSelector)))
+			}
+			if got1 != tt.want1 {
+				t.Errorf("ExtractRSSI() got1 = %v, want %v", got1, tt.want1)
+			}
+		})
+	}
+}
+
+
+func helper()  *C1G2ReadOpSpecResult{
+	val := C1G2ReadOpSpecResult{C1G2ReadOpSpecResultType: 1, OpSpecID: impjDualTarget, Data: []uint16{1,2}}
+	return &val
+}
+
+func TestReadDataAsHex(t *testing.T) {
+	type fields struct {
+		EPCData                                 EPCData
+		EPC96                                   EPC96
+		ROSpecID                                *ROSpecID
+		SpecIndex                               *SpecIndex
+		InventoryParameterSpecID                *InventoryParameterSpecID
+		AntennaID                               *AntennaID
+		PeakRSSI                                *PeakRSSI
+		ChannelIndex                            *ChannelIndex
+		FirstSeenUTC                            *FirstSeenUTC
+		FirstSeenUptime                         *FirstSeenUptime
+		LastSeenUTC                             *LastSeenUTC
+		LastSeenUptime                          *LastSeenUptime
+		TagSeenCount                            *TagSeenCount
+		C1G2PC                                  *C1G2PC
+		C1G2XPCW1                               *C1G2XPCW1
+		C1G2XPCW2                               *C1G2XPCW2
+		C1G2CRC                                 *C1G2CRC
+		AccessSpecID                            *AccessSpecID
+		C1G2ReadOpSpecResult                    *C1G2ReadOpSpecResult
+		C1G2WriteOpSpecResult                   *C1G2WriteOpSpecResult
+		C1G2KillOpSpecResult                    *C1G2KillOpSpecResult
+		C1G2LockOpSpecResult                    *C1G2LockOpSpecResult
+		C1G2BlockEraseOpSpecResult              *C1G2BlockEraseOpSpecResult
+		C1G2BlockWriteOpSpecResult              *C1G2BlockWriteOpSpecResult
+		C1G2RecommissionOpSpecResult            *C1G2RecommissionOpSpecResult
+		C1G2BlockPermalockOpSpecResult          *C1G2BlockPermalockOpSpecResult
+		C1G2GetBlockPermalockStatusOpSpecResult *C1G2GetBlockPermalockStatusOpSpecResult
+		ClientRequestOpSpecResult               *ClientRequestOpSpecResult
+		Custom                                  []Custom
+	}
+
+	tests := []struct {
+		name     string
+		fields   fields
+		wantData string
+		wantOk   bool
+	}{
+		{
+			name: "OK - nil",
+			fields: fields{C1G2ReadOpSpecResult: nil},
+			wantData: "",
+			wantOk: false,
+		},
+		{
+			name: "OK - default values",
+			fields: fields{C1G2ReadOpSpecResult: new(C1G2ReadOpSpecResult)},
+			wantData: wordsToHex([]uint16{}),
+			wantOk: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rt := &TagReportData{
+				EPCData:                                 tt.fields.EPCData,
+				EPC96:                                   tt.fields.EPC96,
+				ROSpecID:                                tt.fields.ROSpecID,
+				SpecIndex:                               tt.fields.SpecIndex,
+				InventoryParameterSpecID:                tt.fields.InventoryParameterSpecID,
+				AntennaID:                               tt.fields.AntennaID,
+				PeakRSSI:                                tt.fields.PeakRSSI,
+				ChannelIndex:                            tt.fields.ChannelIndex,
+				FirstSeenUTC:                            tt.fields.FirstSeenUTC,
+				FirstSeenUptime:                         tt.fields.FirstSeenUptime,
+				LastSeenUTC:                             tt.fields.LastSeenUTC,
+				LastSeenUptime:                          tt.fields.LastSeenUptime,
+				TagSeenCount:                            tt.fields.TagSeenCount,
+				C1G2PC:                                  tt.fields.C1G2PC,
+				C1G2XPCW1:                               tt.fields.C1G2XPCW1,
+				C1G2XPCW2:                               tt.fields.C1G2XPCW2,
+				C1G2CRC:                                 tt.fields.C1G2CRC,
+				AccessSpecID:                            tt.fields.AccessSpecID,
+				C1G2ReadOpSpecResult:                    tt.fields.C1G2ReadOpSpecResult,
+				C1G2WriteOpSpecResult:                   tt.fields.C1G2WriteOpSpecResult,
+				C1G2KillOpSpecResult:                    tt.fields.C1G2KillOpSpecResult,
+				C1G2LockOpSpecResult:                    tt.fields.C1G2LockOpSpecResult,
+				C1G2BlockEraseOpSpecResult:              tt.fields.C1G2BlockEraseOpSpecResult,
+				C1G2BlockWriteOpSpecResult:              tt.fields.C1G2BlockWriteOpSpecResult,
+				C1G2RecommissionOpSpecResult:            tt.fields.C1G2RecommissionOpSpecResult,
+				C1G2BlockPermalockOpSpecResult:          tt.fields.C1G2BlockPermalockOpSpecResult,
+				C1G2GetBlockPermalockStatusOpSpecResult: tt.fields.C1G2GetBlockPermalockStatusOpSpecResult,
+				ClientRequestOpSpecResult:               tt.fields.ClientRequestOpSpecResult,
+				Custom:                                  tt.fields.Custom,
+			}
+			gotData, gotOk := rt.ReadDataAsHex()
+			if gotData != tt.wantData {
+				t.Errorf("ReadDataAsHex() gotData = %v, want %v", gotData, tt.wantData)
+			}
+			if gotOk != tt.wantOk {
+				t.Errorf("ReadDataAsHex() gotOk = %v, want %v", gotOk, tt.wantOk)
+			}
+		})
+	}
+}
+
+func TestIs(t *testing.T) {
+	type fields struct {
+		VendorID uint32
+		Subtype  uint32
+		Data     []byte
+	}
+	type args struct {
+		idType  VendorPEN
+		subtype CustomParamSubtype
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   bool
+	}{
+		{
+			name:   "OK",
+			fields: fields{VendorID: uint32(PENImpinj), Subtype: ImpinjTagReportContentSelector, Data: impinjEnableBool16(ImpinjSearchMode)},
+			args:   args{idType: PENImpinj, subtype: ImpinjTagReportContentSelector},
+			want:   true,
+		},
+		{
+			name:   "OK - mismatched subtype",
+			fields: fields{VendorID: uint32(PENImpinj), Subtype: ImpinjTagReportContentSelector, Data: impinjEnableBool16(ImpinjEnablePeakRSSI)},
+			args:   args{idType: PENImpinj, subtype: ImpinjPeakRSSI},
+			want:   false,
+		},
+		{
+			name:   "OK - mismatched idType",
+			fields: fields{VendorID: uint32(PENImpinj), Subtype: ImpinjTagReportContentSelector, Data: impinjEnableBool16(ImpinjEnablePeakRSSI)},
+			args:   args{idType: PENAlien, subtype: ImpinjTagReportContentSelector},
+			want:   false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Custom{
+				VendorID: tt.fields.VendorID,
+				Subtype:  tt.fields.Subtype,
+				Data:     tt.fields.Data,
+			}
+			if got := c.Is(tt.args.idType, tt.args.subtype); got != tt.want {
+				t.Errorf("Is() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
https://github.com/edgexfoundry-holding/rfid-llrp-inventory-service/pull/18#discussion_r588699906
https://github.com/edgexfoundry-holding/rfid-llrp-inventory-service/pull/20#discussion_r630438008

I added missing attributions, and did a gofmt on tests for stylistic changes to make the Makefile happy.

Alexander also thought there was a bug in ReadDataAsHex() found [here](https://github.com/sicoyle/rfid-llrp-inventory-service/blob/add-util-tests/internal/llrp/util.go#L51) where ok should be set to true in the 2nd if block.

Also, I added a cast to `int16` before the conversion to `float64` [here](https://github.com/edgexfoundry-holding/rfid-llrp-inventory-service/blob/8ff30228317c48a127a79d58e3b33bed1e108c96/internal/llrp/util.go#L39). This is due to the fact that conversion to`int16` should be needed to capture a negative value if the first bit is 1.

I reverted changes for the below comment as @NeethuES-intel addresses this one in her PR:
https://github.com/edgexfoundry-holding/rfid-llrp-inventory-service/pull/18#discussion_r588694504


## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

<!-- If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/master/.github/CONTRIBUTING.md -->

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [X] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

Issue Number:


## What is the new behavior?


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [X] No

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
